### PR TITLE
Feature/route53 health checks

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -189,7 +189,7 @@ func (e *Endpoint) GetProviderSpecificProperty(key string) (ProviderSpecificProp
 }
 
 func (e *Endpoint) String() string {
-	return fmt.Sprintf("%s %d IN %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific)
+	return fmt.Sprintf("%s %d IN %s %s %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.SetIdentifier, e.Targets, e.ProviderSpecific, e.Labels)
 }
 
 // DNSEndpointSpec defines the desired state of DNSEndpoint

--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -69,11 +69,11 @@ func ExampleSameEndpoints() {
 		fmt.Println(ep)
 	}
 	// Output:
-	// abc.com 0 IN A test-set-1 1.2.3.4 []
-	// abc.com 0 IN TXT  something []
-	// bbc.com 0 IN CNAME  foo.com []
-	// cbc.com 60 IN CNAME  foo.com []
-	// example.org 0 IN   load-balancer.org []
-	// example.org 0 IN   load-balancer.org [{foo bar}]
-	// example.org 0 IN TXT  load-balancer.org []
+	// abc.com 0 IN A test-set-1 1.2.3.4 [] map[]
+	// abc.com 0 IN TXT  something [] map[]
+	// bbc.com 0 IN CNAME  foo.com [] map[]
+	// cbc.com 60 IN CNAME  foo.com [] map[]
+	// example.org 0 IN   load-balancer.org [] map[]
+	// example.org 0 IN   load-balancer.org [{foo bar}] map[]
+	// example.org 0 IN TXT  load-balancer.org [] map[]
 }

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -984,8 +984,16 @@ func (p *AWSProvider) createHealthCheckIfNeeded(ep *endpoint.Endpoint) (string, 
 	hcConfig := providerSpecificToHealthCheckConfig(ep)
 	log.Infof("endpoint labels when creating health check is %s for %s", ep.Labels, ep.RecordType)
 
-	ownerID := ep.Labels[endpoint.OwnerLabelKey]
-	resource := ep.Labels[endpoint.ResourceLabelKey]
+	var ownerID, resource string
+
+	if ep.RecordType == endpoint.RecordTypeTXT {
+		labels, _ := endpoint.NewLabelsFromString(ep.Targets[0])
+		ownerID = labels[endpoint.OwnerLabelKey]
+		resource = labels[endpoint.ResourceLabelKey]
+	} else {
+		ownerID = ep.Labels[endpoint.OwnerLabelKey]
+		resource = ep.Labels[endpoint.ResourceLabelKey]
+	}
 
 	healthCheckID, exists := p.healthCheckExists(ownerID, resource)
 	if exists {

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -821,3 +821,13 @@ func getAnnotationKeyFromSuffix(suffix string) string {
 	k := strings.TrimPrefix(suffix, "aws/")
 	return fmt.Sprintf("external-dns.alpha.kubernetes.io/aws-%s", k)
 }
+
+func isExternalDNSOwner(tagset map[string]string) bool {
+	for tagKey := range tagset {
+		if tagKey == "owner" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -310,7 +310,7 @@ func (p *AWSProvider) records(zones map[string]*route53.HostedZone) ([]*endpoint
 					if r.HealthCheckId != nil {
 						tags, err := p.tagsForHealthCheck(aws.StringValue(r.HealthCheckId))
 						if err != nil {
-							log.Errorf("failed to get health check tags for health check id %s. error: %v", r.HealthCheckId, err)
+							log.Errorf("failed to get health check tags for health check id %s. error: %v", aws.StringValue(r.HealthCheckId), err)
 							return false
 						}
 
@@ -325,7 +325,7 @@ func (p *AWSProvider) records(zones map[string]*route53.HostedZone) ([]*endpoint
 							// and make changes accordingly.
 							healthCheck, err := p.getHealthCheck(aws.StringValue(r.HealthCheckId))
 							if err != nil {
-								log.Errorf("failed to get health check with id %q. error: %v", r.HealthCheckId, err)
+								log.Errorf("failed to get health check with id %q. error: %v", aws.StringValue(r.HealthCheckId), err)
 								return false
 							}
 							healthCheckConfigToProviderSpecific(healthCheck.HealthCheckConfig, ep)
@@ -977,6 +977,10 @@ func (p *AWSProvider) getHealthCheck(healthCheckID string) (*route53.HealthCheck
 }
 
 func (p *AWSProvider) createHealthCheckIfNeeded(ep *endpoint.Endpoint) (string, error) {
+	if _, ok := ep.GetProviderSpecificProperty(providerSpecificHealthCheckFQDN); !ok {
+		return "", nil
+	}
+
 	hcConfig := providerSpecificToHealthCheckConfig(ep)
 	log.Infof("endpoint labels when creating health check is %s for %s", ep.Labels, ep.RecordType)
 

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -46,6 +46,7 @@ const (
 	providerSpecificGeolocationCountryCode     = "aws/geolocation-country-code"
 	providerSpecificGeolocationSubdivisionCode = "aws/geolocation-subdivision-code"
 	providerSpecificMultiValueAnswer           = "aws/multi-value-answer"
+	providerSpecificHealthCheckID              = "aws/health-check-id"
 )
 
 var (
@@ -290,6 +291,11 @@ func (p *AWSProvider) records(zones map[string]*route53.HostedZone) ([]*endpoint
 			for _, ep := range newEndpoints {
 				if r.SetIdentifier != nil {
 					ep.SetIdentifier = aws.StringValue(r.SetIdentifier)
+
+					if r.HealthCheckId != nil {
+						ep.WithProviderSpecific(providerSpecificHealthCheckID, aws.StringValue(r.HealthCheckId))
+					}
+
 					switch {
 					case r.Weight != nil:
 						ep.WithProviderSpecific(providerSpecificWeight, fmt.Sprintf("%d", aws.Int64Value(r.Weight)))
@@ -557,6 +563,10 @@ func (p *AWSProvider) newChange(action string, ep *endpoint.Endpoint, recordsCac
 		}
 		if useGeolocation {
 			change.ResourceRecordSet.GeoLocation = geolocation
+		}
+
+		if prop, ok := ep.GetProviderSpecificProperty(providerSpecificHealthCheckID); ok {
+			change.ResourceRecordSet.HealthCheckId = aws.String(prop.Value)
 		}
 	}
 

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -584,9 +584,17 @@ func (p *AWSProvider) newChange(action string, ep *endpoint.Endpoint, recordsCac
 }
 
 func (p *AWSProvider) tagsForZone(zoneID string) (map[string]string, error) {
+	return p.tagsForResource(zoneID, route53.TagResourceTypeHostedzone)
+}
+
+func (p *AWSProvider) tagsForHealthCheck(zoneID string) (map[string]string, error) {
+	return p.tagsForResource(zoneID, route53.TagResourceTypeHealthcheck)
+}
+
+func (p *AWSProvider) tagsForResource(resourceID, resourceType string) (map[string]string, error) {
 	response, err := p.client.ListTagsForResource(&route53.ListTagsForResourceInput{
-		ResourceType: aws.String("hostedzone"),
-		ResourceId:   aws.String(zoneID),
+		ResourceType: aws.String(resourceType),
+		ResourceId:   aws.String(resourceID),
 	})
 	if err != nil {
 		return nil, err

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -72,6 +72,22 @@ func NewRoute53APIStub() *Route53APIStub {
 	}
 }
 
+func (r *Route53APIStub) ChangeTagsForResource(input *route53.ChangeTagsForResourceInput) (*route53.ChangeTagsForResourceOutput, error) {
+	return &route53.ChangeTagsForResourceOutput{}, nil
+}
+
+func (r *Route53APIStub) ListHealthChecks(input *route53.ListHealthChecksInput) (*route53.ListHealthChecksOutput, error) {
+	return &route53.ListHealthChecksOutput{}, nil
+}
+
+func (r *Route53APIStub) CreateHealthCheck(input *route53.CreateHealthCheckInput) (*route53.CreateHealthCheckOutput, error) {
+	return &route53.CreateHealthCheckOutput{}, nil
+}
+
+func (r *Route53APIStub) GetHealthCheck(input *route53.GetHealthCheckInput) (*route53.GetHealthCheckOutput, error) {
+	return &route53.GetHealthCheckOutput{}, nil
+}
+
 func (r *Route53APIStub) ListResourceRecordSetsPages(input *route53.ListResourceRecordSetsInput, fn func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool)) error {
 	output := route53.ListResourceRecordSetsOutput{} // TODO: Support optional input args.
 	if len(r.recordSets) <= 0 {
@@ -100,6 +116,26 @@ func NewRoute53APICounter(w Route53API) *Route53APICounter {
 		wrapped: w,
 		calls:   map[string]int{},
 	}
+}
+
+func (c *Route53APICounter) ChangeTagsForResource(input *route53.ChangeTagsForResourceInput) (*route53.ChangeTagsForResourceOutput, error) {
+	c.calls["ChangeTagsForResource"]++
+	return c.wrapped.ChangeTagsForResource(input)
+}
+
+func (c *Route53APICounter) ListHealthChecks(input *route53.ListHealthChecksInput) (*route53.ListHealthChecksOutput, error) {
+	c.calls["ListHealthChecks"]++
+	return c.wrapped.ListHealthChecks(input)
+}
+
+func (c *Route53APICounter) CreateHealthCheck(input *route53.CreateHealthCheckInput) (*route53.CreateHealthCheckOutput, error) {
+	c.calls["CreateHealthCheck"]++
+	return c.wrapped.CreateHealthCheck(input)
+}
+
+func (c *Route53APICounter) GetHealthCheck(input *route53.GetHealthCheckInput) (*route53.GetHealthCheckOutput, error) {
+	c.calls["GetHealthCheck"]++
+	return c.wrapped.GetHealthCheck(input)
 }
 
 func (c *Route53APICounter) ListResourceRecordSetsPages(input *route53.ListResourceRecordSetsInput, fn func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool)) error {

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/plan"
-	"github.com/kubernetes-incubator/external-dns/source"
 )
 
 const (
@@ -41,6 +40,9 @@ const (
 	cloudFlareUpdate = "UPDATE"
 	// defaultCloudFlareRecordTTL 1 = automatic
 	defaultCloudFlareRecordTTL = 1
+
+	//cloudflareProxiedKey is local const for cloudFlareProxiedKey
+	cloudflareProxiedKey = "external-dns.alpha.kubernetes.io/cloudflare-proxied"
 )
 
 var cloudFlareTypeNotSupported = map[string]bool{
@@ -337,10 +339,10 @@ func shouldBeProxied(endpoint *endpoint.Endpoint, proxiedByDefault bool) bool {
 	proxied := proxiedByDefault
 
 	for _, v := range endpoint.ProviderSpecific {
-		if v.Name == source.CloudflareProxiedKey {
+		if v.Name == cloudflareProxiedKey {
 			b, err := strconv.ParseBool(v.Value)
 			if err != nil {
-				log.Errorf("Failed to parse annotation [%s]: %v", source.CloudflareProxiedKey, err)
+				log.Errorf("Failed to parse annotation [%s]: %v", cloudflareProxiedKey, err)
 			} else {
 				proxied = b
 			}
@@ -385,7 +387,7 @@ func groupByNameAndType(records []cloudflare.DNSRecord) []*endpoint.Endpoint {
 				records[0].Type,
 				endpoint.TTL(records[0].TTL),
 				targets...).
-				WithProviderSpecific(source.CloudflareProxiedKey, strconv.FormatBool(records[0].Proxied)))
+				WithProviderSpecific(cloudflareProxiedKey, strconv.FormatBool(records[0].Proxied)))
 	}
 
 	return endpoints

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -50,3 +50,8 @@ func ensureTrailingDot(hostname string) string {
 
 	return strings.TrimSuffix(hostname, ".") + "."
 }
+
+//AddDefaultProviderSpecificAnnotations returns provider specific property defaults if needed
+func AddDefaultProviderSpecificAnnotations(annotations map[string]string) []endpoint.ProviderSpecificProperty {
+	return addDefaultAWSProviderSpecificAnnotations(annotations)
+}

--- a/source/source.go
+++ b/source/source.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/provider"
 )
 
 const (
@@ -116,6 +117,9 @@ func getProviderSpecificAnnotations(annotations map[string]string) (endpoint.Pro
 			})
 		}
 	}
+
+	providerSpecificAnnotations = append(providerSpecificAnnotations, provider.AddDefaultProviderSpecificAnnotations(annotations)...)
+
 	return providerSpecificAnnotations, setIdentifier
 }
 


### PR DESCRIPTION
This adds the ability to create the health checks using external-dns.

I am kind of split on if this functioanlity belongs to external-dns or another controller. (one reason is that the way external-dns is implemented, we will have to retro fit the health check creation there).

in my current implementation, I've do a cache in provider object, while external dns do caching in registry. 

lets not merge it until we are convinced which way we want to go.